### PR TITLE
configure_logging stack overflow when no methods match

### DIFF
--- a/src/MicroLogging.jl
+++ b/src/MicroLogging.jl
@@ -474,6 +474,7 @@ function configure_logging(args...; kwargs...)
     logger
 end
 
+configure_logging(::AbstractLogger, args...; kwargs...) = throw(ArgumentError("No configure_logging method matches the provided arguments."))
 
 """
     disable_logging(level)
@@ -494,4 +495,3 @@ end
 
 
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using MicroLogging
-using Base.Test 
+using Base.Test
 import MicroLogging: LogLevel, BelowMinLevel, Debug, Info, Warn, Error, NoLogs
 
 if VERSION < v"0.6-"
@@ -209,6 +209,7 @@ end
         @debug "a"
         @info  "b"
         configure_logging(min_level=Error)
+        @test_throws ArgumentError configure_logging("unknown_argument")
         @warn  "c"
         @error "d"
         logs = logger.records


### PR DESCRIPTION
`configure_logging` can get stuck in a loop when the no arguments match for a custom logger type.

```julia
julia> MicroLogging
julia> using Roames.CommandLine # My logger
julia> configure_logging(MicroLogging.Debug) # This works as it should
Roames.RoamesLogging.RoamesLogger(Debug)
julia> configure_logging(min_level = MicroLogging.Debug) # This should just error because I am not support kw args, but instead it stack over flows
 ERROR: StackOverflowError:
Stacktrace:
 [1] (::MicroLogging.#kw##configure_logging)(::Array{Any,1}, ::MicroLogging.#configure_logging, ::Roames.RoamesLogging.RoamesLogger, ::Roames.RoamesLogging.RoamesLogger, ::Roames.RoamesLogging.RoamesLogger, ::Vararg{Roames.RoamesLogging.RoamesLogger,N} where N) at ./<missing>:0
 [2] #configure_logging#9(::Array{Any,1}, ::Function, ::Roames.RoamesLogging.RoamesLogger, ::Vararg{Roames.RoamesLogging.RoamesLogger,N} where N) at /home/josh/.julia/v0.6/MicroLogging/src/MicroLogging.jl:468
 [3] (::MicroLogging.#kw##configure_logging)(::Array{Any,1}, ::MicroLogging.#configure_logging, ::Roames.RoamesLogging.RoamesLogger, ::Roames.RoamesLogging.RoamesLogger, ::Roames.RoamesLogging.RoamesLogger, ::Vararg{Roames.RoamesLogging.RoamesLogger,N} where N) at ./<missing>:0
 [4] #configure_logging#9(::Array{Any,1}, ::Function, ::Roames.RoamesLogging.RoamesLogger, ::Vararg{Roames.RoamesLogging.RoamesLogger,N} where N) at /home/josh/.julia/v0.6/MicroLogging/src/MicroLogging.jl:468
   ... keeps looping etc
```

New behaviour:
```julia
julia> MicroLogging
julia> using Roames.CommandLine # My logger
julia> configure_logging(min_level = MicroLogging.Debug)
ERROR: ArgumentError: No configure_logging method matches the provided arguments.
Stacktrace:
 [1] (::MicroLogging.#kw##configure_logging)(::Array{Any,1}, ::MicroLogging.#configure_logging, ::Roames.RoamesLogging.RoamesLogger) at ./<missing>:0
 [2] #configure_logging#9(::Array{Any,1}, ::Function) at /home/josh/.julia/v0.6/MicroLogging/src/MicroLogging.jl:468
 [3] (::MicroLogging.#kw##configure_logging)(::Array{Any,1}, ::MicroLogging.#configure_logging) at ./<missing>:0
```
