### PR TITLE
Parse log levels as a String

### DIFF
--- a/src/MicroLogging.jl
+++ b/src/MicroLogging.jl
@@ -63,7 +63,7 @@ function Base.show(io::IO, level::LogLevel)
 end
 
 parse_level(level) = level
-parse_level(level::String) = Symbol(tolower(level))
+parse_level(level::String) = parse_level(Symbol(lowercase(level)))
 function parse_level(level::Symbol)
     if      level == :belowminlevel  return  BelowMinLevel
     elseif  level == :debug          return  Debug

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,6 +258,11 @@ end
         @test logs[1] ⊃ (Error, "d")
         @test length(logs) == 1
 
+        disable_logging("Warn")
+        logs = log_each_level()
+        @test logs[1] ⊃ (Error, "d")
+        @test length(logs) == 1
+
         disable_logging(Error)
         logs = log_each_level()
         @test length(logs) == 0


### PR DESCRIPTION
Small bug fix to parse a string log level.