### PR TITLE
Return of the progress bars

### DIFF
--- a/src/MicroLogging.jl
+++ b/src/MicroLogging.jl
@@ -41,6 +41,8 @@ else
     include("core.jl")
 end
 
+include("StickyMessages.jl")
+
 include("ConsoleLogger.jl")
 include("InteractiveLogger.jl") # deprecated
 

--- a/src/StickyMessages.jl
+++ b/src/StickyMessages.jl
@@ -1,0 +1,117 @@
+"""
+    StickyMessages(io::IO; tty=io isa Base.TTY)
+
+A `StickyMessages` type manages the display of a set of persistent "sticky"
+messages in a terminal. That is, messages which are not part of the normal
+scrolling output. Each message is identified by a label and may may be added to
+the set using `push!(messages, label=>msg)`, and removed using
+`pop!(messages, label)`, or `empty!()`.
+
+Only a single StickyMessages object should be associated with a given TTY, as
+the object manipulates the terminal scrolling region.
+"""
+mutable struct StickyMessages
+    io::IO
+    # Bool for controlling TTY escape codes. Will be deduced from io type by default.
+    tty::Bool
+    # Messages is just used as a (short) OrderedDict here
+    messages::Vector{Pair{Any,String}}
+end
+
+function StickyMessages(io::IO; tty=io isa Base.TTY &&
+                                    # give up on Windows for now, as escape
+                                    # codes seem kinda broken there.
+                                    !Compat.Sys.iswindows())
+    sticky = StickyMessages(io, tty, Vector{Pair{Any,String}}())
+    # Ensure we clean up the terminal
+    @compat finalizer(empty!, sticky)
+    sticky
+end
+
+# Count newlines in a message or sequence of messages
+_countlines(msg::String) = sum(c->c=='\n', msg)
+_countlines(messages) = length(messages) > 0 ? sum(_countlines, messages) : 0
+_countlines(messages::Vector{<:Pair}) = _countlines(m[2] for m in messages)
+
+# Selected TTY cursor and screen control via ANSI codes
+# * https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences
+# * See man terminfo on linux, eg `tput csr $row1 $row2` and `tput cup $row $col`
+# * For windows see https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+change_scroll_region!(io, rows::Pair) = write(io, "\e[$(rows[1]);$(rows[2])r")
+change_cursor_line!(io, line::Integer) = write(io, "\e[$line;1H")
+clear_to_end!(io) = write(io, "\e[J")
+
+function showsticky(io, prev_nlines, messages)
+    height,_ = displaysize(io)
+    iob = IOBuffer()
+    if prev_nlines > 0
+        change_cursor_line!(iob, height + 1 - prev_nlines)
+        clear_to_end!(iob)
+    end
+    # Set scroll region to the first N lines.
+    #
+    # Terminal scrollback buffers seem to be populated with a heuristic which
+    # relies on the scrollable region starting at the first row, so to have
+    # normal scrollback work we have to position sticky messages at the bottom
+    # of the screen.
+    linesrequired = _countlines(messages)
+    if prev_nlines < linesrequired
+        # Scroll screen up to preserve the lines which we will overwrite
+        change_cursor_line!(iob, height - prev_nlines)
+        write(iob, "\n"^(linesrequired-prev_nlines))
+    end
+    if prev_nlines != linesrequired
+        change_scroll_region!(iob, 1=>height-linesrequired)
+    end
+    # Write messages. Avoid writing \n of last message to kill extra scrolling
+    if !isempty(messages)
+        change_cursor_line!(iob, height + 1 - linesrequired)
+        for i = 1:length(messages)-1
+            write(iob, messages[i][2])
+        end
+        write(iob, messages[end][2][1:end-1])
+    end
+    # TODO: Ideally we'd query the terminal for the line it was on before doing
+    # all this and restore it if it's not in the new non-scrollable region.
+    change_cursor_line!(iob, height - max(prev_nlines, linesrequired))
+    # Write in one block to make the whole operation as atomic as possible.
+    write(io, take!(iob))
+    nothing
+end
+
+function Base.push!(sticky::StickyMessages, message::Pair)
+    if !sticky.tty
+        write(sticky.io, message[2])
+        return
+    end
+    label,text = message
+    endswith(text, '\n') || (text *= '\n';)
+    prev_nlines = _countlines(sticky.messages)
+    idx = Compat.findfirst(m->m[1] == label, sticky.messages)
+    if idx === nothing
+        push!(sticky.messages, label=>text)
+    else
+        sticky.messages[idx] = label=>text
+    end
+    showsticky(sticky.io, prev_nlines, sticky.messages)
+end
+
+function Base.pop!(sticky::StickyMessages, label)
+    sticky.tty || return
+    idx = Compat.findfirst(m->m[1] == label, sticky.messages)
+    if idx !== nothing
+        prev_nlines = _countlines(sticky.messages)
+        deleteat!(sticky.messages, idx)
+        showsticky(sticky.io, prev_nlines, sticky.messages)
+    end
+    nothing
+end
+
+function Base.empty!(sticky::StickyMessages)
+    sticky.tty || return
+    prev_nlines = _countlines(sticky.messages)
+    empty!(sticky.messages)
+    showsticky(sticky.io, prev_nlines, sticky.messages) # Resets scroll region
+    nothing
+end
+

--- a/test/StickyMessages.jl
+++ b/test/StickyMessages.jl
@@ -1,0 +1,38 @@
+using MicroLogging: StickyMessages
+
+@testset "Sticky messages without tty" begin
+    buf = IOBuffer()
+    # Without TTY, messages are just piped through
+    stickies = StickyMessages(buf, tty=false)
+    push!(stickies, :a=>"Msg\n")
+    @test String(take!(buf)) == "Msg\n"
+    push!(stickies, :a=>"Msg\n")
+    @test String(take!(buf)) == "Msg\n"
+    pop!(stickies, :a)
+    @test String(take!(buf)) == ""
+end
+
+@testset "Sticky messages with tty" begin
+    buf = IOBuffer()
+    dsize = (20, 80) # Intentionally different from default of 25 rows
+    # In TTY mode, we generate various escape codes.
+    stickies = StickyMessages(IOContext(buf, :displaysize=>dsize), tty=true)
+    push!(stickies, :a=>"Msg\n")
+    @test String(take!(buf)) ==  #scroll    #csr    #pos   #msg #pos
+                                "\e[20;1H\n\e[1;19r\e[20;1HMsg\e[19;1H"
+    push!(stickies, :a=>"MsgMsg\n")
+    @test String(take!(buf)) == #clear      #msgpos #msg #repos
+                               "\e[20;1H\e[J\e[20;1HMsgMsg\e[19;1H"
+    push!(stickies, :b=>"BBB\n")
+    @test String(take!(buf)) ==
+        #clear       #scroll   #csr    #pos    #msgs      #pos
+        "\e[20;1H\e[J\e[19;1H\n\e[1;18r\e[19;1HMsgMsg\nBBB\e[18;1H"
+    pop!(stickies, :a)
+    @test String(take!(buf)) == #clear       #csr    #pos   #msg #pos
+                                "\e[19;1H\e[J\e[1;19r\e[20;1HBBB\e[18;1H"
+    pop!(stickies, :b)
+    @test String(take!(buf)) == #clear       #csr    #pos
+                                "\e[20;1H\e[J\e[1;20r\e[19;1H"
+    pop!(stickies, :b)
+    @test String(take!(buf)) == ""
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,5 +32,6 @@ end
 
 include("config.jl")
 include("ConsoleLogger.jl")
+include("StickyMessages.jl")
 
 end


### PR DESCRIPTION
Here's some infrastructure for much improved progress bars which sit in a separate non-scrolling region of the terminal, as "sticky" messages.

Allows for progress messages from multiple loops at once, sorted by first appearance. Also allows other messages to be designated "sticky" which is interesting and useful, though mixes content with presentation a little much.